### PR TITLE
Fix password confirmation for whitespace passwords

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -155,7 +155,9 @@ module ActiveModel
             end
           end
 
-          validates_confirmation_of attribute, allow_blank: true
+          # Skip confirmation validation only when the password is nil so that
+          # whitespace-only passwords still require a matching confirmation.
+          validates_confirmation_of attribute, allow_nil: true
         end
 
         # Only generate tokens for records that are capable of doing so (Active Records, not vanilla Active Models)

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -104,6 +104,13 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
   end
 
+  test "create a new user with spaces only password and incorrect confirmation" do
+    @user.password = " "
+    @user.password_confirmation = "something else"
+    assert_not @user.valid?(:create), "user should be invalid"
+    assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
+  end
+
   test "resetting password to nil clears the password cache" do
     @user.password = "password"
     @user.password = nil
@@ -176,6 +183,13 @@ class SecurePasswordTest < ActiveModel::TestCase
     @existing_user.password_confirmation = "something else"
     assert_not @existing_user.valid?(:update), "user should be invalid"
     assert_equal 1, @existing_user.errors.count
+    assert_equal ["doesn't match Password"], @existing_user.errors[:password_confirmation]
+  end
+
+  test "updating an existing user with spaces only password and incorrect confirmation" do
+    @existing_user.password = " "
+    @existing_user.password_confirmation = "something else"
+    assert_not @existing_user.valid?(:update), "user should be invalid"
     assert_equal ["doesn't match Password"], @existing_user.errors[:password_confirmation]
   end
 


### PR DESCRIPTION
## Summary
- ensure `has_secure_password` validates password confirmation when the password is whitespace only
- cover whitespace-only passwords with new tests

## Testing
- `activemodel/bin/test test/cases/secure_password_test.rb -n "/spaces only password and incorrect confirmation/"` *(fails: https://github.com/rails/sdoc.git is not yet checked out)*

------
https://chatgpt.com/codex/tasks/task_b_6866b43f6a5883239fd42c2cfece19cd